### PR TITLE
Make app navigation staging-only for cleaner production

### DIFF
--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -40,10 +40,10 @@ const AppNavigation: React.FC = () => {
   const portfolioPages = ['/', '/work', '/about', '/consulting', '/style-guide'];
   const isOnPortfolio = portfolioPages.includes(location.pathname) || location.pathname.startsWith('/project/');
 
-  // Always show navigation if any apps are enabled OR if we're in development/staging
-  const shouldShowNav = enabledNavItems.length > 0 || isOnPortfolio;
-
-  if (!shouldShowNav) {
+  // Only show navigation in staging environment
+  const isStaging = process.env.REACT_APP_ENVIRONMENT === 'staging';
+  
+  if (!isStaging) {
     return null;
   }
 


### PR DESCRIPTION
## 🎯 Clean Production Environment

This PR ensures the app navigation bar only appears in staging for internal development.

### 🚀 Changes

- **Production Clean** - No app navigation bar on alessandrobattisti.com
- **Staging Only** - Navigation appears only when `REACT_APP_ENVIRONMENT=staging`
- **Internal Development** - Keeps staging as the testing ground for feature-flagged apps

### 🔧 Technical Details

- Added environment check: `process.env.REACT_APP_ENVIRONMENT === 'staging'`
- Production builds will have completely clean interface
- Staging maintains full feature flag development experience

### 📋 Result

**Production (alessandrobattisti.com):**
- Clean portfolio site with no development navigation
- Professional appearance for visitors

**Staging (staging.alessandrobattisti.com):**
- Full feature flag system with navigation
- Internal testing and development environment

This maintains a clear separation between production and development environments.